### PR TITLE
Overridden two additional methods from ViewPager.

### DIFF
--- a/library/src/main/java/com/antonyt/infiniteviewpager/InfiniteViewPager.java
+++ b/library/src/main/java/com/antonyt/infiniteviewpager/InfiniteViewPager.java
@@ -30,9 +30,25 @@ public class InfiniteViewPager extends ViewPager {
     @Override
     public void setCurrentItem(int item) {
         // offset the current item to ensure there is space to scroll
-        item = getOffsetAmount() + (item % getAdapter().getCount());
-        super.setCurrentItem(item);
+        setCurrentItem(item, false);
+    }
 
+    @Override
+    public void setCurrentItem(int item, boolean smoothScroll) {
+        item = getOffsetAmount() + (item % getAdapter().getCount());
+        super.setCurrentItem(item, smoothScroll);
+    }
+
+    @Override
+    public int getCurrentItem() {
+        int position = super.getCurrentItem();
+        if (getAdapter() instanceof InfinitePagerAdapter) {
+            InfinitePagerAdapter infAdapter = (InfinitePagerAdapter) getAdapter();
+            // Return the actual item position in the data backing InfinitePagerAdapter
+            return (position % infAdapter.getRealCount());
+        } else {
+            return super.getCurrentItem();
+        }
     }
 
     private int getOffsetAmount() {
@@ -47,5 +63,4 @@ public class InfiniteViewPager extends ViewPager {
             return 0;
         }
     }
-
 }


### PR DESCRIPTION
Since setCurrentItem() refers to a "real" position and not "virtual" position, override the implementation of `getCurrentItem()` to reflect this. It now returns the actual position of the object that is
backing the adapter.

Also fixes #8 setCurrentItem(int, boolean) has the same implementation as
setCurrentItem(int) except with smoothScroll
