### PR TITLE
Add getPageTitle() for PagerTitleStrip

### DIFF
--- a/library/src/main/java/com/antonyt/infiniteviewpager/InfinitePagerAdapter.java
+++ b/library/src/main/java/com/antonyt/infiniteviewpager/InfinitePagerAdapter.java
@@ -83,6 +83,12 @@ public class InfinitePagerAdapter extends PagerAdapter {
         adapter.startUpdate(container);
     }
 
+    @Override
+    public CharSequence getPageTitle(int position) {
+        int virtualPosition = position % getRealCount();
+        return adapter.getPageTitle(virtualPosition);
+    }
+
     /*
      * End delegation
      */


### PR DESCRIPTION
[PagerTitleStrip](http://developer.android.com/intl/ja/reference/android/support/v4/view/PagerTitleStrip.html) is required page titles. But currently InfinitePagerAdapter's `getPageTitle()` returns null. I override it to return true titles.
