### PR TITLE
Offset only for the first setCurrentItem

### DIFF
--- a/library/src/main/java/com/antonyt/infiniteviewpager/InfiniteViewPager.java
+++ b/library/src/main/java/com/antonyt/infiniteviewpager/InfiniteViewPager.java
@@ -39,7 +39,9 @@ public class InfiniteViewPager extends ViewPager {
             super.setCurrentItem(item, smoothScroll);
             return;
         }
-        item = getOffsetAmount() + (item % getAdapter().getCount());
+        // offset only for the first time
+        if (item < getOffsetAmount())
+            item = getOffsetAmount() + (item % getAdapter().getCount());
         super.setCurrentItem(item, smoothScroll);
     }
 


### PR DESCRIPTION
When trying to do stuffs like auto scrolling,
setCurrentItem has to be used for every auto scroll.

Current version of setCurrentItem can't be used more than once because it adds offset to item every time.

This pull request resolves the issue.